### PR TITLE
Fix sass-loader version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "eslint": "^6.7.2",
     "eslint-plugin-vue": "^6.0.1",
     "sass": "^1.23.7",
-    "sass-loader": "^8.0.0",
+    "sass-loader": "7.3.1",
     "stylelint": "^13.0.0",
     "vue-template-compiler": "^2.6.10"
   }


### PR DESCRIPTION
sass-loader v8.0 no funciona bien con vue cli, como reportan en este bug:
https://github.com/vuejs/vue-cli/issues/4526